### PR TITLE
fix: update airflow kubernetes provider version

### DIFF
--- a/docker/airflow/requirements.txt
+++ b/docker/airflow/requirements.txt
@@ -1,4 +1,4 @@
-apache-airflow-providers-kubernetes==7.8.0
+apache-airflow-providers-kubernetes==9.0.0
 apache-airflow-providers-redis==3.4.1
 apache-airflow-providers-http==4.6.0
 requests==2.31.0


### PR DESCRIPTION
## Summary
- update airflow kubernetes provider version for docker build

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891eed1b0b48332af20488fe453c131