### PR TITLE
Add Airflow worker deployment manifest

### DIFF
--- a/kubernetes/airflow/airflow-worker.yaml
+++ b/kubernetes/airflow/airflow-worker.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-worker
+  namespace: llm-production
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: airflow-worker
+  template:
+    metadata:
+      labels:
+        app: airflow-worker
+    spec:
+      serviceAccountName: airflow
+      containers:
+      - name: worker
+        image: airflow:latest
+        imagePullPolicy: IfNotPresent
+        command: ["airflow", "celery", "worker"]
+        envFrom:
+        - secretRef:
+            name: airflow-secrets
+        - configMapRef:
+            name: airflow-config
+        volumeMounts:
+        - name: dags
+          mountPath: /opt/airflow/dags
+        - name: logs
+          mountPath: /opt/airflow/logs
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "500m"
+          limits:
+            memory: "2Gi"
+            cpu: "1"
+      volumes:
+      - name: dags
+        configMap:
+          name: airflow-dags
+      - name: logs
+        emptyDir: {}


### PR DESCRIPTION
## Summary
- add deployment manifest for Airflow Celery worker

## Testing
- `python - <<'PY'
import sys, yaml
with open('kubernetes/airflow/airflow-worker.yaml') as f:
    yaml.safe_load(f)
print('YAML parsed successfully')
PY`
- `kubectl apply --dry-run=client -f kubernetes/airflow/airflow-worker.yaml` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68949672982883328663e690dd694a61