### PR TITLE
Add Prometheus configuration for monitoring stack

### DIFF
--- a/kubernetes/monitoring/prometheus.yaml
+++ b/kubernetes/monitoring/prometheus.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: llm-production
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+      - job_name: prometheus
+        static_configs:
+          - targets: ['localhost:9090']
+      - job_name: llm-service
+        static_configs:
+          - targets: ['llm-service:8000']
+      - job_name: airflow
+        static_configs:
+          - targets: ['airflow-webserver:8080']
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: llm-production
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus:v2.49.0
+        args:
+        - "--config.file=/etc/prometheus/prometheus.yml"
+        - "--storage.tsdb.path=/prometheus"
+        ports:
+        - containerPort: 9090
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus/
+        - name: data
+          mountPath: /prometheus
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      volumes:
+      - name: config
+        configMap:
+          name: prometheus-config
+      - name: data
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: llm-production
+spec:
+  selector:
+    app: prometheus
+  ports:
+  - port: 9090
+    targetPort: 9090


### PR DESCRIPTION
## Summary
- add Prometheus config, deployment, and service for monitoring
- ensure Grafana is configured to use Prometheus datasource and ingress route

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import sys, pathlib, yaml
print('Loaded YAML version', yaml.__version__)
path=pathlib.Path('kubernetes/monitoring/prometheus.yaml')
print('Parsing', path)
with open(path) as f:
    docs=list(yaml.safe_load_all(f))
print('Loaded', len(docs), 'documents')
PY`
- `python - <<'PY'
import yaml, pathlib
path=pathlib.Path('kubernetes/monitoring/grafana.yaml')
with open(path) as f:
    docs=list(yaml.safe_load_all(f))
print('Loaded grafana docs', len(docs))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68949a6376548332bab0b2b5a5fb101a