### PR TITLE
Use official Airflow image and fix PVC storage class

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Two helper scripts automate cluster setup and deployment:
 1. **Build images**
    ```bash
    docker build -t llm-service:latest docker/llm-service
-   docker build -t airflow:latest docker/airflow
    ```
+   The deployment uses the official Apache Airflow image `apache/airflow:2.7.3-python3.10`, so no additional build step is required.
 2. **Set up cluster prerequisites**
    ```bash
    ./scripts/setup.sh

--- a/kubernetes/airflow/airflow-scheduler.yaml
+++ b/kubernetes/airflow/airflow-scheduler.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: airflow
       containers:
       - name: scheduler
-        image: airflow:latest
+        image: apache/airflow:2.7.3-python3.10
         imagePullPolicy: IfNotPresent
         command: ["airflow", "scheduler"]
         envFrom:

--- a/kubernetes/airflow/airflow-webserver.yaml
+++ b/kubernetes/airflow/airflow-webserver.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: airflow
       initContainers:
       - name: airflow-init
-        image: airflow:latest
+        image: apache/airflow:2.7.3-python3.10
         imagePullPolicy: IfNotPresent
         command: ["airflow", "db", "init"]
         envFrom:
@@ -24,7 +24,7 @@ spec:
             name: airflow-secrets
       containers:
       - name: webserver
-        image: airflow:latest
+        image: apache/airflow:2.7.3-python3.10
         imagePullPolicy: IfNotPresent
         command: ["airflow", "webserver"]
         ports:

--- a/kubernetes/airflow/airflow-worker.yaml
+++ b/kubernetes/airflow/airflow-worker.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: airflow
       containers:
       - name: worker
-        image: airflow:latest
+        image: apache/airflow:2.7.3-python3.10
         imagePullPolicy: IfNotPresent
         command: ["airflow", "celery", "worker"]
         envFrom:

--- a/kubernetes/llm-service/pvc.yaml
+++ b/kubernetes/llm-service/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   resources:
     requests:
       storage: 50Gi
-  storageClassName: standard
+  storageClassName: hostpath

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -27,11 +27,9 @@ kubectl wait --namespace ingress-nginx \
 if [[ $(kubectl config current-context) == "kind-"* ]]; then
     echo "Loading images into kind cluster..."
     kind load docker-image llm-service:latest
-    kind load docker-image airflow:latest
 elif [[ $(kubectl config current-context) == "minikube" ]]; then
     echo "Loading images into minikube..."
     minikube image load llm-service:latest
-    minikube image load airflow:latest
 fi
 
 # Create ConfigMaps for Airflow DAGs


### PR DESCRIPTION
## Summary
- fix Airflow deployments to use official `apache/airflow:2.7.3-python3.10` image instead of missing `airflow:latest`
- ensure llm-service PVC uses `hostpath` storage class for Docker Desktop
- streamline setup script and docs for updated image workflow

## Testing
- `kubectl version --client` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894a069042883328ca4d7ac0f92bd4a