### PR TITLE
Tune Airflow worker resource requests

### DIFF
--- a/kubernetes/airflow/airflow-worker.yaml
+++ b/kubernetes/airflow/airflow-worker.yaml
@@ -31,11 +31,11 @@ spec:
           mountPath: /opt/airflow/logs
         resources:
           requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
             memory: "1Gi"
             cpu: "500m"
-          limits:
-            memory: "2Gi"
-            cpu: "1"
       volumes:
       - name: dags
         configMap:


### PR DESCRIPTION
## Summary
- lower Airflow worker memory request to 512Mi and CPU request to 250m
- adjust limits to 1Gi memory and 500m CPU

## Testing
- `kubectl apply -f kubernetes/airflow/airflow-worker.yaml` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894a3c257f48332922e086440cd5ebc