### PR TITLE
Reduce llm-service resource allocation

### DIFF
--- a/kubernetes/llm-service/deployment.yaml
+++ b/kubernetes/llm-service/deployment.yaml
@@ -27,11 +27,11 @@ spec:
             name: llm-service-config
         resources:
           requests:
-            memory: "8Gi"
-            cpu: "2"
+            memory: "2Gi"
+            cpu: "1"
           limits:
-            memory: "16Gi"
-            cpu: "4"
+            memory: "4Gi"
+            cpu: "2"
         volumeMounts:
         - name: model-storage
           mountPath: /app/models


### PR DESCRIPTION
## Summary
- shrink llm-service resource requests to 2Gi memory and 1 CPU
- set resource limits to 4Gi memory and 2 CPU

## Testing
- `kubectl apply -f kubernetes/llm-service/deployment.yaml` *(fails: command not found: kubectl)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y kubectl` *(fails: Unable to locate package kubectl)*

------
https://chatgpt.com/codex/tasks/task_e_6894a3c66c7c8332ae3f0c1000fa023c